### PR TITLE
Allow for exclusion of key-value pairs and use SupportSQLiteDatabase interface to be able to support other SQLiteDatabase implementations

### DIFF
--- a/BackupAPI/build.gradle
+++ b/BackupAPI/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.sqlite:sqlite-ktx:2.1.0'
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/BackupAPI/src/main/java/org/secuso/privacyfriendlybackup/api/backup/DatabaseUtil.kt
+++ b/BackupAPI/src/main/java/org/secuso/privacyfriendlybackup/api/backup/DatabaseUtil.kt
@@ -5,14 +5,14 @@ import android.content.Context
 import android.database.Cursor.*
 import android.database.sqlite.SQLiteDatabase
 import android.util.JsonReader
-import android.util.JsonWriter
 import android.util.JsonToken
+import android.util.JsonWriter
 import androidx.core.database.getBlobOrNull
 import androidx.core.database.getFloatOrNull
 import androidx.core.database.getIntOrNull
 import androidx.core.database.getStringOrNull
+import androidx.sqlite.db.SupportSQLiteDatabase
 import org.secuso.privacyfriendlybackup.api.util.toBase64
-import java.io.StringReader
 import java.io.StringWriter
 
 /**
@@ -27,7 +27,7 @@ import java.io.StringWriter
 object DatabaseUtil {
 
     @JvmStatic
-    fun writeDatabase(writer: JsonWriter, db: SQLiteDatabase) {
+    fun writeDatabase(writer: JsonWriter, db: SupportSQLiteDatabase) {
         writer.beginObject()
         writer.name("version").value(db.version)
         writer.name("content")
@@ -36,7 +36,7 @@ object DatabaseUtil {
     }
 
     @JvmStatic
-    fun writeDatabaseContent(writer: JsonWriter, db : SQLiteDatabase) {
+    fun writeDatabaseContent(writer: JsonWriter, db : SupportSQLiteDatabase) {
         writer.beginArray()
         val tableInfo = getTables(db)
         for(table in tableInfo) {
@@ -56,10 +56,10 @@ object DatabaseUtil {
     }
 
     @JvmStatic
-    fun getTables(db : SQLiteDatabase) : List<Pair<String, String?>> {
+    fun getTables(db : SupportSQLiteDatabase) : List<Pair<String, String?>> {
         val resultList = ArrayList<Pair<String, String?>>()
 
-        db.query("sqlite_master", arrayOf("name", "sql"), "type = ?", arrayOf("table"), null, null, null).use { cursor ->
+        db.query("SELECT name, sql FROM sqlite_master WHERE type='table'").use { cursor ->
             cursor.moveToFirst()
             while(!cursor.isAfterLast) {
                 val name = cursor.getStringOrNull(cursor.getColumnIndex("name")) ?: ""
@@ -72,9 +72,9 @@ object DatabaseUtil {
     }
 
     @JvmStatic
-    fun writeTable(writer: JsonWriter, db : SQLiteDatabase, table: String) {
+    fun writeTable(writer: JsonWriter, db : SupportSQLiteDatabase, table: String) {
         writer.beginArray()
-        db.query(table, null, null, null, null, null, null).use { cursor ->
+        db.query("SELECT * FROM $table").use { cursor ->
             cursor.moveToFirst()
             while(!cursor.isAfterLast) {
                 writer.beginObject()
@@ -113,7 +113,7 @@ object DatabaseUtil {
     }
 
     @JvmStatic
-    fun readDatabaseContent(reader: JsonReader, db: SQLiteDatabase) {
+    fun readDatabaseContent(reader: JsonReader, db: SupportSQLiteDatabase) {
         reader.beginArray()
 
         while(reader.hasNext()) {
@@ -124,7 +124,7 @@ object DatabaseUtil {
     }
 
     @JvmStatic
-    fun readTable(reader: JsonReader, db: SQLiteDatabase) {
+    fun readTable(reader: JsonReader, db: SupportSQLiteDatabase) {
         reader.beginObject()
 
         // tableName
@@ -147,7 +147,7 @@ object DatabaseUtil {
     }
 
     @JvmStatic
-    fun readValues(reader: JsonReader, db: SQLiteDatabase, tableName: String) {
+    fun readValues(reader: JsonReader, db: SupportSQLiteDatabase, tableName: String) {
         reader.beginArray()
         while(reader.hasNext()) {
             reader.beginObject()
@@ -163,7 +163,7 @@ object DatabaseUtil {
                 }
                 cv.put(name, value)
             }
-            db.insert(tableName, null, cv)
+            db.insert(tableName, SQLiteDatabase.CONFLICT_NONE, cv)
             reader.endObject()
         }
         reader.endArray()
@@ -182,14 +182,14 @@ object DatabaseUtil {
 
 }
 
-fun SQLiteDatabase.toJSON() : String {
+fun SupportSQLiteDatabase.toJSON() : String {
     val writer = JsonWriter(StringWriter())
     writer.setIndent("")
     DatabaseUtil.writeDatabase(writer, this)
     return writer.toString()
 }
 
-fun SQLiteDatabase.toReadableJSON() : String {
+fun SupportSQLiteDatabase.toReadableJSON() : String {
     val writer = JsonWriter(StringWriter())
     writer.setIndent("  ")
     DatabaseUtil.writeDatabase(writer, this)

--- a/BackupAPI/src/main/java/org/secuso/privacyfriendlybackup/api/backup/PreferenceUtil.kt
+++ b/BackupAPI/src/main/java/org/secuso/privacyfriendlybackup/api/backup/PreferenceUtil.kt
@@ -10,8 +10,18 @@ import android.util.JsonWriter
 object PreferenceUtil {
     @JvmStatic
     fun writePreferences(writer: JsonWriter, pref: SharedPreferences) {
+        writePreferences(writer, pref, emptyArray())
+    }
+
+    @JvmStatic
+    fun writePreferences(writer: JsonWriter, pref: SharedPreferences, excludedKeys: Array<String>) {
         writer.beginObject()
         for((key, value) in pref.all) {
+            // Continue if key-value pair should be excluded from the backup
+            if(key in excludedKeys) {
+                continue
+            }
+
             writer.name(key)
 
             // App should know the types of the keys when it sees them.


### PR DESCRIPTION
Excluding key-value pairs is important [when you don't want to include passphrases in your backups](https://github.com/SecUSo/privacy-friendly-finance-manager/blob/a6ebe9bae974b4014852bd25d34344cabae7709d/app/src/main/java/org/secuso/privacyfriendlyfinance/backup/BackupCreator.java#L47).

The other change is very useful when using an sqlite encryption layer like [android-database-sqlcipher](https://github.com/sqlcipher/android-database-sqlcipher), which features it's own ``SQLiteDatabase``implementation. This generalization is essential to be able to support backups in [privacy-friendly-finance-manager](https://github.com/SecUSo/privacy-friendly-finance-manager/pull/27).