### PR TITLE
Always interpret FIELD_TYPE_INTEGER as long to prevent integer overflow

### DIFF
--- a/BackupAPI/src/main/java/org/secuso/privacyfriendlybackup/api/backup/DatabaseUtil.kt
+++ b/BackupAPI/src/main/java/org/secuso/privacyfriendlybackup/api/backup/DatabaseUtil.kt
@@ -5,14 +5,13 @@ import android.content.Context
 import android.database.Cursor.*
 import android.database.sqlite.SQLiteDatabase
 import android.util.JsonReader
-import android.util.JsonWriter
 import android.util.JsonToken
+import android.util.JsonWriter
 import androidx.core.database.getBlobOrNull
 import androidx.core.database.getFloatOrNull
-import androidx.core.database.getIntOrNull
+import androidx.core.database.getLongOrNull
 import androidx.core.database.getStringOrNull
 import org.secuso.privacyfriendlybackup.api.util.toBase64
-import java.io.StringReader
 import java.io.StringWriter
 
 /**
@@ -86,7 +85,7 @@ object DatabaseUtil {
                                 writer.value(cursor.getStringOrNull(i))
                             }
                             FIELD_TYPE_INTEGER ->   {
-                                writer.value(cursor.getIntOrNull(i))
+                                writer.value(cursor.getLongOrNull(i))
                             }
                             FIELD_TYPE_FLOAT ->     {
                                 writer.value(cursor.getFloatOrNull(i))


### PR DESCRIPTION
Here's an example:

<img width="330px" src="https://user-images.githubusercontent.com/62917820/147896803-d47dc48b-6351-4840-9209-0f2a79f8d9b1.png">
<img width="210px" src="https://user-images.githubusercontent.com/62917820/147896808-f4dfdb0f-86b1-4928-851f-08e2c6c99253.png">

