### PR TITLE
Upgrade target API, build tools and dependencies

### DIFF
--- a/BackupAPI/build.gradle
+++ b/BackupAPI/build.gradle
@@ -1,17 +1,22 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-parcelize'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'kotlin-parcelize'
+}
 
 android {
-    compileSdkVersion 32
+    compileSdk 33
+    buildFeatures {
+        viewBinding true
+    }
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -22,34 +27,35 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
+    buildFeatures {
+        aidl true
+    }
+    namespace 'org.secuso.privacyfriendlybackup.api'
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    testImplementation 'junit:junit:4.13.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
-    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    def work_version = "2.7.1"
+    def work_version = '2.8.1'
     implementation "androidx.work:work-runtime:$work_version"
     implementation "androidx.work:work-runtime-ktx:$work_version"
     androidTestImplementation "androidx.work:work-testing:$work_version"
 
-    implementation "androidx.sqlite:sqlite-ktx:2.2.0"
-    implementation 'androidx.sqlite:sqlite-framework:2.2.0'
-
+    implementation 'androidx.sqlite:sqlite-ktx:2.3.1'
+    implementation 'androidx.sqlite:sqlite-framework:2.3.1'
 }


### PR DESCRIPTION
Starting on August 31, 2023 all App updates must target Android 13, see https://developer.android.com/google/play/requirements/target-sdk